### PR TITLE
Development updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /spec/reports/
 /tmp/
 /Gemfile.lock
+/gemfiles/*.gemfile.lock

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,1 +1,4 @@
 ruby_version: 2.3
+ignore:
+  - 'vendor/**/*'
+  - 'gemfiles/vendor/**/*'

--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ Just run the below command to test with all supported DB engines.
 $ docker-compose run test
 ```
 
+Or run with a specific ActiveRecord version
+
+```
+$ docker-compose run -e AR_VERSION=6.1 test
+```
+
+Or run tests locally, without docker-compose
+
+```
+$ AR_VERSION=4.2 bundle update && AR_VERSION=4.2 bundle exec rake test
+```
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/gemfiles/5.2.gemfile
+++ b/gemfiles/5.2.gemfile
@@ -1,3 +1,5 @@
+source "https://rubygems.org"
+
 gem "activesupport", "~> 5.2"
 gem "activemodel", "~> 5.2"
 gem "activerecord", "~> 5.2"

--- a/gemfiles/6.0.gemfile
+++ b/gemfiles/6.0.gemfile
@@ -1,3 +1,5 @@
+source "https://rubygems.org"
+
 gem "activesupport", "~> 6.0"
 gem "activemodel", "~> 6.0"
 gem "activerecord", "~> 6.0"

--- a/gemfiles/6.1.gemfile
+++ b/gemfiles/6.1.gemfile
@@ -1,3 +1,5 @@
+source "https://rubygems.org"
+
 gem "activesupport", "~> 6.1.0"
 gem "activemodel", "~> 6.1.0"
 gem "activerecord", "~> 6.1.0"


### PR DESCRIPTION
 * Added a source to our gemfiles, resolving the deprecation notice
 * Provide an example in the README on running the tests against a specific version
 * Git ignore gemfile locks to avoid accidental check-in and have standardrb ignore the vendor contents to avoid unnecessary reporting.
 