### PR TITLE
Allow custom ULID primary keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ulid-rails CHANGELOG
 
+## Unreleased
+
+ - Allow custom ULID primary keys
+
 ## 0.5
 
 - Ensure ULID order respects timestamp order to millisecond precision.

--- a/lib/ulid/rails.rb
+++ b/lib/ulid/rails.rb
@@ -13,6 +13,8 @@ module ULID
 
     class_methods do
       def ulid(column_name, primary_key: false, auto_generate: nil)
+        self.primary_key = column_name if primary_key
+
         attribute column_name, ULID::Rails::Type.new
 
         auto_generate = primary_key || auto_generate

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -66,6 +66,10 @@ ActiveRecord::Schema.define do
     t.binary :user_id, limit: 16
   end
 
+  create_table(:custom, id: false) do |t|
+    t.binary :unique_id, limit: 16, primary_key: true
+  end
+
   create_table(:user_articles, id: false) do |t|
     t.binary :id, limit: 16, primary_key: true
     t.binary :user_id, limit: 16
@@ -88,6 +92,13 @@ class User < ActiveRecord::Base
   has_many :books
   has_many :user_articles
   has_many :articles, through: :user_articles
+end
+
+class Custom < ActiveRecord::Base
+  self.table_name = "custom"
+
+  include ULID::Rails
+  ulid :unique_id, primary_key: true
 end
 
 class Book < ActiveRecord::Base

--- a/test/ulid/rails_test.rb
+++ b/test/ulid/rails_test.rb
@@ -11,6 +11,15 @@ class ULID::RailsTest < Minitest::Test
     assert id == user.id
   end
 
+  def test_custom_primary_key
+    assert Custom.primary_key != "id"
+    assert Custom.primary_key == "unique_id"
+
+    custom = Custom.create!
+    assert custom.unique_id.is_a? String
+    assert custom.unique_id.length == 26
+  end
+
   def test_has_many
     user = User.create!
     book = user.books.create!


### PR DESCRIPTION
Prior to this change clients of ulid-rails were unable to set a primary key with a column name other than "id".

Source:
https://github.com/rails/rails/blob/83217025a171593547d1268651b446d3533e2019/activerecord/lib/active_record/attribute_methods/primary_key.rb#L104-L123