### PR TITLE
Support for Rails 4.2, 5.0 & 5.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,18 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
-      matrix: 
-        activerecord-version: ["5.2", "6.0", "6.1"]
+      matrix:
+        activerecord-version: ["4.2", "5.0", "5.1", "5.2", "6.0", "6.1"]
         ruby-version: ["2.6", "2.7", "3.0"]
         exclude:
+          - activerecord-version: "4.2"
+            ruby-version: "2.7"
+          - activerecord-version: "4.2"
+            ruby-version: "3.0"
+          - activerecord-version: "5.0"
+            ruby-version: "3.0"
+          - activerecord-version: "5.1"
+            ruby-version: "3.0"
           - activerecord-version: "5.2"
             ruby-version: "3.0"
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ulid-rails CHANGELOG
 
+## Unreleased
+
+ - Add support for Rails 4.2, 5.0 and 5.1
+
 ## 0.5
 
 - Ensure ULID order respects timestamp order to millisecond precision.

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 4.2"
+gem "activemodel", "~> 4.2"
+gem "activerecord", "~> 4.2"
+gem "sqlite3", "~> 1.3.6"
+gem "mysql2"
+gem "pg", "~> 0.15" # https://github.com/rails/rails/blob/11f2bdf75a888682b34df0f9be03b94f54fc6796/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L15-L17

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 5.0"
+gem "activemodel", "~> 5.0"
+gem "activerecord", "~> 5.0"
+gem "sqlite3", "~> 1.3.6"
+gem "mysql2"
+gem "pg"

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 5.1"
+gem "activemodel", "~> 5.1"
+gem "activerecord", "~> 5.1"
+gem "sqlite3", "~> 1.3.6"
+gem "mysql2"
+gem "pg"

--- a/lib/ulid/rails.rb
+++ b/lib/ulid/rails.rb
@@ -1,6 +1,5 @@
 require "active_record"
 require "active_support/concern"
-require "active_model/type"
 require "ulid"
 require "base32/crockford"
 require "ulid/rails/version"
@@ -45,7 +44,14 @@ module ULID
       end
     end
 
-    ActiveModel::Type.register(:ulid, ULID::Rails::Type)
+    case "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
+    when "4.2"
+      # no-op
+    else
+      require "active_model/type"
+      ActiveModel::Type.register(:ulid, ULID::Rails::Type)
+    end
+
     ActiveRecord::ConnectionAdapters::TableDefinition.send :include, Patch::Migrations
   end
 end

--- a/lib/ulid/rails/type.rb
+++ b/lib/ulid/rails/type.rb
@@ -1,12 +1,20 @@
-require "active_model/type"
 require "ulid/rails/formatter"
 require "ulid/rails/validator"
 require "ulid/rails/errors"
 
 module ULID
   module Rails
-    class Type < ActiveModel::Type::Binary
-      class Data < ActiveModel::Type::Binary::Data
+    case "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
+    when "4.2"
+      require "active_record/type"
+      Binary = ActiveRecord::Type::Binary
+    else
+      require "active_model/type"
+      Binary = ActiveModel::Type::Binary
+    end
+
+    class Type < Binary
+      class Data < Binary::Data
         alias_method :hex, :to_s
       end
 
@@ -39,6 +47,12 @@ module ULID
         when "postgresql"
           Data.new([@formatter.unformat(value)].pack("H*"))
         end
+      end
+
+      case "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
+      when "4.2"
+        alias_method :type_cast_for_database, :serialize
+        alias_method :type_cast_from_database, :deserialize
       end
 
       private

--- a/test/ulid/rails_test.rb
+++ b/test/ulid/rails_test.rb
@@ -39,6 +39,9 @@ class ULID::RailsTest < Minitest::Test
   end
 
   def test_validate_ulid_format
+    # Validation was introduced in 5.0, https://github.com/rails/rails/commit/8e633e505880755e7e366ccec2210bbe2b5436e7
+    return if "4.2" == "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
+
     non_ulid_id = "I am not a ulid"
 
     assert_raises(ULID::Rails::ArgumentError) { User.new(id: non_ulid_id) }

--- a/ulid-rails.gemspec
+++ b/ulid-rails.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "ulid", "~> 1.0"
   spec.add_dependency "base32-crockford", "~> 0.1"
-  spec.add_dependency "activesupport", ">= 5.0"
-  spec.add_dependency "activemodel", ">= 5.0"
-  spec.add_dependency "activerecord", ">= 5.0"
+  spec.add_dependency "activesupport", ">= 4.2"
+  spec.add_dependency "activemodel", ">= 4.2"
+  spec.add_dependency "activerecord", ">= 4.2"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
Test with Rails 4.2

There are still services using Rails 4.2. Let's release a
version of the ulid-rails with support for this old version.

We're not limiting ourselves by providing this support and if we do
find ourselves limited, we can phase out the support.

With these changes older Rails services will at least have _a_ version
of ulid-rails that they can use until they upgrade 🙂