### PR TITLE
Add support for Rails 4.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,14 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
-      matrix: 
-        activerecord-version: ["5.2", "6.0", "6.1"]
+      matrix:
+        activerecord-version: ["4.2", "5.2", "6.0", "6.1"]
         ruby-version: ["2.6", "2.7", "3.0"]
         exclude:
+          - activerecord-version: "4.2"
+            ruby-version: "2.7"
+          - activerecord-version: "4.2"
+            ruby-version: "3.0"
           - activerecord-version: "5.2"
             ruby-version: "3.0"
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ulid-rails CHANGELOG
 
+## Unreleased
+
+ - Add support for Rails 4.2.
+
 ## 0.5
 
 - Ensure ULID order respects timestamp order to millisecond precision.

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -1,0 +1,6 @@
+gem "activesupport", "~> 4.2"
+gem "activemodel", "~> 4.2"
+gem "activerecord", "~> 4.2"
+gem "sqlite3", "~> 1.3.6"
+gem "mysql2", ">= 0.3.13", "< 0.6.0"
+gem "pg", "~> 0.15"

--- a/lib/ulid/rails.rb
+++ b/lib/ulid/rails.rb
@@ -1,11 +1,11 @@
 require "active_record"
 require "active_support/concern"
-require "active_model/type"
 require "ulid"
 require "base32/crockford"
 require "ulid/rails/version"
 require "ulid/rails/type"
 require "ulid/rails/patch"
+require "ulid/rails/constants"
 
 module ULID
   module Rails
@@ -45,7 +45,11 @@ module ULID
       end
     end
 
-    ActiveModel::Type.register(:ulid, ULID::Rails::Type)
+    unless RAILS_4_2
+      require "active_model/type"
+      ActiveModel::Type.register(:ulid, ULID::Rails::Type)
+    end
+
     ActiveRecord::ConnectionAdapters::TableDefinition.send :include, Patch::Migrations
   end
 end

--- a/lib/ulid/rails/constants.rb
+++ b/lib/ulid/rails/constants.rb
@@ -1,0 +1,6 @@
+module ULID
+  module Rails
+    RAILS_VERSION = "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
+    RAILS_4_2 = RAILS_VERSION == "4.2"
+  end
+end

--- a/lib/ulid/rails/type.rb
+++ b/lib/ulid/rails/type.rb
@@ -1,12 +1,21 @@
-require "active_model/type"
 require "ulid/rails/formatter"
 require "ulid/rails/validator"
 require "ulid/rails/errors"
+require "ulid/rails/constants"
 
 module ULID
   module Rails
-    class Type < ActiveModel::Type::Binary
-      class Data < ActiveModel::Type::Binary::Data
+    case RAILS_VERSION
+    when "4.2"
+      require "active_record/type"
+      Binary = ActiveRecord::Type::Binary
+    else
+      require "active_model/type"
+      Binary = ActiveModel::Type::Binary
+    end
+
+    class Type < Binary
+      class Data < Binary::Data
         alias_method :hex, :to_s
       end
 
@@ -38,6 +47,16 @@ module ULID
           Data.new(@formatter.unformat(value))
         when "postgresql"
           Data.new([@formatter.unformat(value)].pack("H*"))
+        end
+      end
+
+      if RAILS_4_2
+        alias_method :type_cast_for_database, :serialize
+        alias_method :type_cast_from_database, :deserialize
+
+        def type_cast_from_user(value)
+          assert_valid_value(value)
+          super
         end
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -83,6 +83,8 @@ end
 
 class User < ActiveRecord::Base
   include ULID::Rails
+  self.primary_key = :id
+
   ulid :id, primary_key: true
 
   has_many :books
@@ -92,6 +94,8 @@ end
 
 class Book < ActiveRecord::Base
   include ULID::Rails
+  self.primary_key = :id
+
   ulid :id, primary_key: true
   ulid :user_id
 
@@ -100,6 +104,8 @@ end
 
 class UserArticle < ActiveRecord::Base
   include ULID::Rails
+  self.primary_key = :id
+
   ulid :id, primary_key: true
   ulid :user_id
   ulid :article_id
@@ -110,6 +116,8 @@ end
 
 class Article < ActiveRecord::Base
   include ULID::Rails
+  self.primary_key = :id
+
   ulid :id, primary_key: true
 end
 

--- a/ulid-rails.gemspec
+++ b/ulid-rails.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "ulid", "~> 1.0"
   spec.add_dependency "base32-crockford", "~> 0.1"
-  spec.add_dependency "activesupport", ">= 5.0"
-  spec.add_dependency "activemodel", ">= 5.0"
-  spec.add_dependency "activerecord", ">= 5.0"
+  spec.add_dependency "activesupport", ">= 4.2"
+  spec.add_dependency "activemodel", ">= 4.2"
+  spec.add_dependency "activerecord", ">= 4.2"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
We are adding support for Rails 4.2 as there are still services using
this version. But we can also phase out this support if we find
ourselves limited in the future.

Since Rails 4.2 has a different way of dealing with primary keys, we
keep the responsibility of defining the primary key outside the type
definition. As this is not what the gem is expected to do.