### PR TITLE
Add support for Rails 5.0 and 5.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        activerecord-version: ["4.2", "5.2", "6.0", "6.1"]
+        activerecord-version: ["5.0", "5.1", "4.2", "5.2", "6.0", "6.1"]
         ruby-version: ["2.6", "2.7", "3.0"]
         exclude:
           - activerecord-version: "4.2"
             ruby-version: "2.7"
           - activerecord-version: "4.2"
+            ruby-version: "3.0"
+          - activerecord-version: "5.0"
+            ruby-version: "3.0"
+          - activerecord-version: "5.1"
             ruby-version: "3.0"
           - activerecord-version: "5.2"
             ruby-version: "3.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
- - Add support for Rails 4.2.
+ - Add support for Rails 4.2, 5.0 and 5.1.
 
 ## 0.5
 

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -1,0 +1,6 @@
+gem "activesupport", "~> 5.0"
+gem "activemodel", "~> 5.0"
+gem "activerecord", "~> 5.0"
+gem "sqlite3", "~> 1.3.6"
+gem "mysql2", ">= 0.3.18", "< 0.6.0"
+gem "pg", ">= 0.18", "< 2.0"

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -1,0 +1,6 @@
+gem "activesupport", "~> 5.1"
+gem "activemodel", "~> 5.1"
+gem "activerecord", "~> 5.1"
+gem "sqlite3", "~> 1.3", ">= 1.3.6"
+gem "mysql2", ">= 0.3.18", "< 0.6.0"
+gem "pg", ">= 0.18", "< 2.0"


### PR DESCRIPTION
Since we are supporting Rails 4.2 and 5.2, it is a good idea to also support versions in between.