### PR TITLE
Fix ULID Validator

### DIFF
--- a/lib/ulid/rails/validator.rb
+++ b/lib/ulid/rails/validator.rb
@@ -3,9 +3,14 @@ require "base32/crockford"
 module ULID
   module Rails
     module Validator
+      INVALID_CHARACTERS_REGEX = /[ilou]/i.freeze
+
       def self.is_valid?(v)
         return true if v.nil?
-        v.length == 26 && Base32::Crockford.valid?(v)
+        return false unless v.length == 26
+        return false if INVALID_CHARACTERS_REGEX.match?(v)
+        
+        Base32::Crockford.valid?(v)
       end
     end
   end

--- a/test/ulid/rails/validator_test.rb
+++ b/test/ulid/rails/validator_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class ULID::Rails::ValidatorTest < Minitest::Test
+  def test_length_less_than_26
+    id = "A" * 25
+
+    assert ULID::Rails::Validator.is_valid?(id) == false
+  end
+
+  def test_length_greater_than_26
+    id = "A" * 27
+
+    assert ULID::Rails::Validator.is_valid?(id) == false
+  end
+
+  # Crockford's Base32 is used as shown. This alphabet excludes 
+  # the letters I, L, O, and U to avoid confusion and abuse.
+  # https://github.com/ulid/spec#encoding
+  def test_has_invalid_characters
+    invalid_characters = %w(I L O U)
+
+    invalid_characters.each do |char|
+      id = char * 26
+
+      assert ULID::Rails::Validator.is_valid?(id) == false
+    end
+  end
+
+  def test_has_valid_characters_only
+    id = "01BX5ZZKBKACTAV9WEVGEMMVRZ"
+
+    assert ULID::Rails::Validator.is_valid?(id) == true
+  end
+end


### PR DESCRIPTION
This PR tries to demonstrate that the current ULID Validator implementation incorrectly validates some invalid inputs.
The Crockford's base32 alphabet excludes certain characters (I, L, O, and U) for better readability's sake. However, this implementation of the validator recognizes these characters as valid ones.

Source: [Official ULID spec](https://github.com/ulid/spec#encoding)

A follow-up commit will attempt to fix this but it'll take some time because I suspect that some fix needs to be made in the `base32/crockford` gem first.