### PR TITLE
Fix gemfiles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,2 @@
-source "https://rubygems.org"
-
-git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
-
-# Specify your gem's dependencies in ulid-rails.gemspec
-gemspec
-
 version = ENV["AR_VERSION"] || "6.0"
 eval_gemfile File.expand_path("../gemfiles/#{version}.gemfile", __FILE__)

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -1,6 +1,10 @@
-gem "activesupport", "~> 5.0"
-gem "activemodel", "~> 5.0"
-gem "activerecord", "~> 5.0"
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "activesupport", "~> 5.0.0"
+gem "activemodel", "~> 5.0.0"
+gem "activerecord", "~> 5.0.0"
 gem "sqlite3", "~> 1.3.6"
 gem "mysql2", ">= 0.3.18", "< 0.6.0"
 gem "pg", ">= 0.18", "< 2.0"

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -1,6 +1,10 @@
-gem "activesupport", "~> 5.1"
-gem "activemodel", "~> 5.1"
-gem "activerecord", "~> 5.1"
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "activesupport", "~> 5.1.0"
+gem "activemodel", "~> 5.1.0"
+gem "activerecord", "~> 5.1.0"
 gem "sqlite3", "~> 1.3", ">= 1.3.6"
 gem "mysql2", ">= 0.3.18", "< 0.6.0"
 gem "pg", ">= 0.18", "< 2.0"

--- a/gemfiles/5.2.gemfile
+++ b/gemfiles/5.2.gemfile
@@ -1,8 +1,10 @@
 source "https://rubygems.org"
 
-gem "activesupport", "~> 5.2"
-gem "activemodel", "~> 5.2"
-gem "activerecord", "~> 5.2"
+gemspec path: ".."
+
+gem "activesupport", "~> 5.2.0"
+gem "activemodel", "~> 5.2.0"
+gem "activerecord", "~> 5.2.0"
 gem "sqlite3", "~> 1.3.6"
 gem "mysql2"
 gem "pg"

--- a/gemfiles/6.0.gemfile
+++ b/gemfiles/6.0.gemfile
@@ -1,8 +1,10 @@
 source "https://rubygems.org"
 
-gem "activesupport", "~> 6.0"
-gem "activemodel", "~> 6.0"
-gem "activerecord", "~> 6.0"
+gemspec path: ".."
+
+gem "activesupport", "~> 6.0.0"
+gem "activemodel", "~> 6.0.0"
+gem "activerecord", "~> 6.0.0"
 gem "sqlite3", "~> 1.4.1"
 gem "mysql2"
 gem "pg"

--- a/gemfiles/6.1.gemfile
+++ b/gemfiles/6.1.gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+gemspec path: ".."
+
 gem "activesupport", "~> 6.1.0"
 gem "activemodel", "~> 6.1.0"
 gem "activerecord", "~> 6.1.0"


### PR DESCRIPTION
We were using ~> wrong: `~> 5.0` might install 5.x.x, not 5.0.x. So we have lately probably only been running tests for Rails 5.2 and 6.1.

Also adding the `gemspec` call into each gemfile, and fixing the root Gemfile to not specify a global source twice.