### PR TITLE
CI: Fix events triggering lint/test jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,12 @@
 ---
 name: Linting
-on: [push, pull_request]
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
 jobs:
   standardrb:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,12 @@
 ---
 name: Tests
-on: [push, pull_request]
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
With the old configuration, we would run CI twice when pushing a commit and opening a pull request. Or when pushing a commit that belongs to a pull request.

With the new configuration, we run CI once when opening a PR, and once when pushing a commit that belongs to a pull request. And once when merging to master (the `push` event). Importantly, this configuration still works for contributions from forked repositories, since the `pull_request` events are triggered on _our_ fork.