### PR TITLE
Make ULID::Rails::Formatter.unformat more resilient and prevent gsub error

### DIFF
--- a/lib/ulid/rails/formatter.rb
+++ b/lib/ulid/rails/formatter.rb
@@ -9,7 +9,7 @@ module ULID
       end
 
       def self.unformat(v)
-        Base32::Crockford.decode(v).to_s(16).rjust(32, "0")
+        Base32::Crockford.decode(v.to_s).to_i.to_s(16).rjust(32, "0")
       end
     end
   end


### PR DESCRIPTION
## Issue

I'm currently working on porting my existing app over to using ULID instead of integer IDs and I've been using this gem. Once I got everything migrated over, I began hitting the same issue that @gjtorikian hit in https://github.com/k2nr/ulid-rails/issues/32. 

Essentially what I see is that for some reason the value being passed to `unformat` is the full data type and not a string which `gsub` can be called on (ex: `#<ULID::Rails::Type::Data:0x000000010d9b6258 @value="\x01\x81\xD0@\xC0\xAAaO\x9D\xF9+\x0FZ\xE3VS">`)

## Possible Fix

By calling `to_s` I am able to ensure that if the data type is passed in it becomes the string value. I then need to call `to_i` so that the argument in `to_s(16)` will be valid. 

Honestly I'm fairly unfamiliar with what's happening here exactly and I mostly just hacked this together to unblock myself but I wanted to put it forward in case anyone else hits it. This is happening deep inside of a batch loader in my GraphQL implementation and I haven't been able to track down exactly what's going on. 

I did try writing some tests to reproduce the issue but I was unable to. 