### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Specify `id: false` to `create_table` and add `id` column as 16-byte binary type
   end
 ```
 
+**MySQL note:** You can also declare the `id` column as `t.column :id, 'binary(16)'` when using MySQL, given that the syntax in the example will generate a SQL that makes the id as `VARBINARY(16)` instead of `BINARY(16)`.
+
 ### Model Changes
 
 Just add the below lines to your models.


### PR DESCRIPTION
Adding an entry in the readme about MySQL. It has a different way of declaring BINARY type.
 P.S : in #49 We discovered that this doesn't apply to all. Example: it didn't work for Postgres.