### PR TITLE
Drop support to ruby 2.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         activerecord-version: ["5.0", "5.1", "5.2", "6.0", "6.1", "7.0"]
-        ruby-version: ["2.6", "2.7", "3.0", "3.1"]
+        ruby-version: ["2.7", "3.0", "3.1"]
         exclude:
           - {activerecord-version: "5.0", ruby-version: "3.0"}
           - {activerecord-version: "5.0", ruby-version: "3.1"}
@@ -23,7 +23,6 @@ jobs:
           - {activerecord-version: "5.2", ruby-version: "3.0"}
           - {activerecord-version: "5.2", ruby-version: "3.1"}
           - {activerecord-version: "6.0", ruby-version: "3.1"}
-          - {activerecord-version: "7.0", ruby-version: "2.6"}
     steps:
       - uses: actions/checkout@v3
       - name: Test ActiveRecord ${{ matrix.activerecord-version }} and Ruby ${{ matrix.ruby-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ulid-rails CHANGELOG
 
+## Unreleased
+
+- Drop support for ruby 2.6.
+
 ## 1.1.0
 
 - Fix eager loading with limit/offset on models that have ulid primary key. The fix only applies to ActiveRecord 5.2, 6 and 7 (#38).


### PR DESCRIPTION
Dropping support for ruby 2.6