### PR TITLE
Make ULID::Rails::Formatter.unformat more resilient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Make `ULID::Rails::Formatter.unformat` more resilient wrt. different data types.
+
 ## 1.1.1
 
 - Drop support for ruby 2.6.

--- a/lib/ulid/rails/formatter.rb
+++ b/lib/ulid/rails/formatter.rb
@@ -9,7 +9,8 @@ module ULID
       end
 
       def self.unformat(v)
-        Base32::Crockford.decode(v).to_s(16).rjust(32, "0")
+        decoded_i = Base32::Crockford.decode(v.to_s).to_i
+        decoded_i.to_s(16).rjust(32, "0")
       end
     end
   end

--- a/lib/ulid/rails/formatter.rb
+++ b/lib/ulid/rails/formatter.rb
@@ -4,12 +4,16 @@ module ULID
   module Rails
     module Formatter
       def self.format(v)
+        # v is 32 lowercase hex
+        # sanitized is 37 integers
         sanitized = v.delete("-").hex
         Base32::Crockford.encode(sanitized).rjust(26, "0")
       end
 
       def self.unformat(v)
         decoded_i = Base32::Crockford.decode(v.to_s).to_i
+        # v is 26 digits/uppercase letters
+        # decoded_i is 37 integers
         decoded_i.to_s(16).rjust(32, "0")
       end
     end

--- a/test/ulid/rails_test.rb
+++ b/test/ulid/rails_test.rb
@@ -88,6 +88,42 @@ class ULID::RailsTest < Minitest::Test
     assert_equal [user], result
   end
 
+  def test_find_with_where_and_singular_string_arg
+    user = User.create!
+
+    assert_equal [user], User.where(id: user.id)
+  end
+
+  def test_find_with_where_and_singular_integer_arg
+    User.create!
+
+    assert_empty User.where(id: 42)
+  end
+
+  def test_find_with_where_and_singular_weird_arg
+    User.create!
+
+    assert_empty User.where(id: Date.new)
+  end
+
+  def test_find_with_where_and_string_array
+    user = User.create!
+
+    assert_equal [user], User.where(id: [user.id, "x"])
+  end
+
+  def test_find_with_where_and_integer_array
+    User.create!
+
+    assert_empty User.where(id: [42, 100])
+  end
+
+  def test_find_with_where_and_mixed_type_array
+    user = User.create!
+
+    assert_equal [user], User.where(id: [42, user.id, Time.now])
+  end
+
   private
 
   def model_classes

--- a/ulid-rails.gemspec
+++ b/ulid-rails.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activemodel", ">= 5.0"
   spec.add_dependency "activerecord", ">= 5.0"
   spec.add_development_dependency "bundler"
+  spec.add_development_dependency "debug"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rubocop-minitest"


### PR DESCRIPTION
Calling `ActiveRecord::Querying#where` with a non-string argument, or with an Array containing non-string arguments, would cause an exception inside `ULID::Rails::Formatter.format`.

Closes #48.