### PR TITLE
Test with ActiveRecord 7.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        activerecord-version: ["6.0", "6.1", "7.0", "7.0.5"]
+        activerecord-version: ["6.0", "6.1", "7.0", "7.0.5", "7.1"]
         ruby-version: ["2.7", "3.0", "3.1", "3.2"]
         include:
           - {activerecord-version: "5.2", ruby-version: "2.7"}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Ensure compatibility with the Trilogy database adapter.
+- Ensure compatibility with Rails 7.1.
 
 ## 2.0.0.pre.2
 

--- a/gemfiles/7.1.gemfile
+++ b/gemfiles/7.1.gemfile
@@ -1,0 +1,11 @@
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "activesupport", "~> 7.1.0"
+gem "activemodel", "~> 7.1.0"
+gem "activerecord", "~> 7.1.0"
+gem "sqlite3", "~> 1.4"
+gem "mysql2", "~> 0.5"
+gem "pg", "~> 1.1"
+gem "trilogy", "~> 2.4"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -64,7 +64,7 @@ if db[:adapter] == "trilogy"
   if ActiveRecord.gem_version < Gem::Version.new("6.0")
     warn "Skipping tests for ActiveRecord v#{ActiveRecord.gem_version} using the #{db[:adapter]} database adapter."
     exit
-  else
+  elsif ActiveRecord.gem_version < Gem::Version.new("7.1")
     require "trilogy_adapter/connection"
     ActiveRecord::Base.extend(TrilogyAdapter::Connection)
   end


### PR DESCRIPTION
Rails 7.1 has been released, and ActiveRecord has changed significantly since v7.0. Let’s run our tests with 7.1 to make sure we’re compatible.