### PR TITLE
Release v2.1.0

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,4 +1,4 @@
-ruby_version: 2.3
+ruby_version: 2.6
 ignore:
   - 'vendor/**/*'
   - 'gemfiles/vendor/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2.1.0
+
+- Make `ULID::Rails::Type::Data.valid_ulid?` more strict in what is accepted as valid and not.
+
 ## 2.0.0
 
 - Ensure compatibility with the Trilogy database adapter.

--- a/lib/ulid/rails/version.rb
+++ b/lib/ulid/rails/version.rb
@@ -1,5 +1,5 @@
 module ULID
   module Rails
-    VERSION = "2.0.0"
+    VERSION = "2.1.0"
   end
 end

--- a/ulid-rails.gemspec
+++ b/ulid-rails.gemspec
@@ -5,7 +5,7 @@ require "ulid/rails/version"
 Gem::Specification.new do |spec|
   spec.name = "ulid-rails"
   spec.version = ULID::Rails::VERSION
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
   spec.authors = ["Kazunori Kajihiro", "Zendesk"]
   spec.email = ["kazunori.kajihiro@gmail.com", "ruby-core@zendesk.com"]
 
@@ -47,5 +47,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rubocop-minitest"
-  spec.add_development_dependency "standard", "~> 1.16.0"
+  spec.add_development_dependency "standard", "~> 1.32.0"
 end


### PR DESCRIPTION
Also changing `required_ruby_version` to v2.6+ because I found out (by upgrading standard) that we’ve been using a Ruby 2.6 feature (endless range) in the last release. 😅 