### PR TITLE
Replace `docker-compose` with `docker compose`

### DIFF
--- a/.github/workflows/rails-main-branch-test.yml
+++ b/.github/workflows/rails-main-branch-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: docker-compose run test
+      - run: docker compose run test
         env:
           RUBY_VERSION: "3.3"
           AR_VERSION: "main"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           - {activerecord-version: "5.2", ruby-version: "2.7"}
     steps:
       - uses: actions/checkout@v4
-      - run: docker-compose run test
+      - run: docker compose run test
         env:
           RUBY_VERSION: ${{ matrix.ruby-version }}
           AR_VERSION: ${{ matrix.activerecord-version }}

--- a/README.md
+++ b/README.md
@@ -152,16 +152,16 @@ and your join class must have `belongs_to` main classes defined as shown in the 
 Just run the below command to test with all supported DB engines.
 
 ```
-$ docker-compose run test
+$ docker compose run test
 ```
 
 Or run with a specific ActiveRecord version
 
 ```
-$ docker-compose run -e AR_VERSION=6.1 test
+$ docker compose run -e AR_VERSION=6.1 test
 ```
 
-Or run tests locally, without docker-compose
+Or run tests locally, without docker compose
 
 ```
 $ AR_VERSION=6.1 bundle update && AR_VERSION=6.1 bundle exec rake test


### PR DESCRIPTION
Docker Compose v1 has been removed from ubuntu-latest runner images. See https://github.com/actions/runner-images/issues/9692